### PR TITLE
Allow for hourly snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/zfsbud.conf

--- a/default.zfsbud.conf
+++ b/default.zfsbud.conf
@@ -10,6 +10,8 @@ weekly=5
 monthly=13
 # The number of snapshots of first sundays of the year to keep.
 yearly=6
+# The number of hourly snapshots to keep (one per hour, starting with this hour and going backward).
+hourly=0
 
 # Other settings
 

--- a/default.zfsbud.conf
+++ b/default.zfsbud.conf
@@ -1,14 +1,14 @@
 # Snapshot retention policy
 
-# Apart from the below,the last snapshot is always kept, as well as the most recent common snapshot (in case the `--send|-s` flag is passed).
+# Apart from the below, the last snapshot is always kept, as well as the most recent common snapshot (in case the `--send|-s` flag is passed).
 
-# The amount of daily snapshots to keep.
+# The number of daily snapshots to keep.
 daily=8
-# The amount of weekly (Sunday) snapshots to keep.
+# The number of weekly (Sunday) snapshots to keep.
 weekly=5
-# The amount of snapshots of first sundays of every month to keep.
+# The number of snapshots of first sundays of every month to keep.
 monthly=13
-# The amount of snapshots of first sundays of the year to keep.
+# The number of snapshots of first sundays of the year to keep.
 yearly=6
 
 # Other settings

--- a/default.zfsbud.conf
+++ b/default.zfsbud.conf
@@ -2,6 +2,8 @@
 
 # Apart from the below, the last snapshot is always kept, as well as the most recent common snapshot (in case the `--send|-s` flag is passed).
 
+# The number of hourly snapshots to keep (one per hour, starting with this hour and going backward).
+hourly=0
 # The number of daily snapshots to keep.
 daily=8
 # The number of weekly (Sunday) snapshots to keep.
@@ -10,8 +12,6 @@ weekly=5
 monthly=13
 # The number of snapshots of first sundays of the year to keep.
 yearly=6
-# The number of hourly snapshots to keep (one per hour, starting with this hour and going backward).
-hourly=0
 
 # Other settings
 


### PR DESCRIPTION
The configurable snapshot retention is great, but in my use case I take hourly backups, which requires matching 10 characters of the snapshot's name rather than 8. I figured why not generalize it somewhat.

Additionally, a couple of related changes:
- Grammer corrections in comments
- Add .gitignore
