### PR TITLE
make snapshot_prefix optional

### DIFF
--- a/zfsbud.sh
+++ b/zfsbud.sh
@@ -70,6 +70,10 @@ for arg in "$@"; do
       snapshot_prefix=$2
       shift
       shift
+    elif [ "x$2" = "x" ] ; then
+      snapshot_prefix=
+      shift
+      shift
     else
       die "--snapshot-prefix|-p requires a prefix string as argument."
     fi
@@ -423,7 +427,7 @@ fi
 [ -v destination_parent_dataset ] && [[ $destination_parent_dataset == *@* ]] && die "--send|s needs to specify the destination dataset name. (Did you provide a snapshot instead?)."
 
 # Allow only letters, numbers and underscores for the snapshot prefix.
-[[ ! $snapshot_prefix =~ ^[A-Za-z0-9_]+$ ]] && die "The snapshot prefix may only contain letters, digits and underscores."
+[[ ! $snapshot_prefix =~ ^[A-Za-z0-9_]*$ ]] && die "The snapshot prefix may only contain letters, digits and underscores."
 
 # Allow only letters, numbers and underscores for the snapshot label.
 [ -v snapshot_label ] && [[ ! $snapshot_label =~ ^[A-Za-z0-9_]+$ ]] && die "The snapshot label may only contain letters, digits and underscores."


### PR DESCRIPTION
The `snapshot_prefix` cannot be empty but is there really a reason for it? One might want to use a snapshot naming schema only consisting of the timestamp without any prefix. This small proposed change makes the `snapshot_prefix` optional so that the `default_snapshot_prefix` can be empty or `--snapshot-prefix ""` can be passed as an argument. Using an empty `snapshot_prefix` does not seem to have any negative side-effect.