### PR TITLE
execute zfs list with dataset

### DIFF
--- a/zfsbud.sh
+++ b/zfsbud.sh
@@ -141,9 +141,9 @@ done
 
 dataset_exists() {
   if [ -v remote_shell ]; then
-    $remote_shell "zfs list -H -o name" | grep -qx "$1" && return 0
+    $remote_shell "zfs list -H -o name $1" | grep -qx "$1" && return 0
   else
-    zfs list -H -o name | grep -qx "$1" && return 0
+    zfs list -H -o name $1 | grep -qx "$1" && return 0
   fi
   return 1
 }
@@ -158,7 +158,7 @@ validate_dataset() {
   # todo Make it work for pools without datasets?
   [[ $dataset == *@* ]] || [[ $dataset != */* ]] && die "Provided parameters need to be source datasets (source/dataset/path1 source/dataset/path2 ...)."
 
-  ! zfs list -H -o name | grep -qx "$dataset" && die "Source dataset '$dataset' does not exist."
+  ! zfs list -H -o name $dataset | grep -qx "$dataset" && die "Source dataset '$dataset' does not exist."
 
   # Validate sending the dataset.
 
@@ -220,11 +220,11 @@ keep_snapshot?() {
 }
 
 get_local_snapshots() {
-  zfs list -H -o name -t snapshot | grep "$1@"
+  zfs list -H -o name -t snapshot $1 | grep "$1@"
 }
 
 get_remote_snapshots() {
-  $remote_shell "zfs list -H -o name -t snapshot | grep $1@"
+  $remote_shell "zfs list -H -o name -t snapshot $1 | grep $1@"
 }
 
 set_source_snapshots() {


### PR DESCRIPTION
Currently all `zfs list` commands are executed without any dataset name, i.e. all zfs datasets on the entire system are gathered and then the output is filter through `grep`.
In order to work more efficient, it would be better to simply pass the name of the desired dataset to `zfs list` so that only this particular zfs dataset is retrieved.
This suggested pull request simply adds the dataset name to all `zfs list` commands.