### PR TITLE
Use GNU date on FreeBSD

### DIFF
--- a/zfsbud.sh
+++ b/zfsbud.sh
@@ -55,6 +55,15 @@ keep_timestamps=()
 kept_timestamps=()
 resume="-s"
 
+# Use GNU date on FreeBSD (issue#28)
+if [ "$(uname -s)" = "FreeBSD" ] && [ "$DATECMD" = "date" ] ; then
+  if [ -x /usr/local/bin/gdate ] ; then
+    DATECMD=/usr/local/bin/gdate
+  else
+    die "GNU date from coreutils must be installed on FreeBSD."
+  fi
+fi
+
 for arg in "$@"; do
   case $arg in
   -c | --create-snapshot)


### PR DESCRIPTION
On FreeBSD GNU date from coreutils must be used instead of BSD date which lacks -d option.
This addresses issue https://github.com/gbytedev/zfsbud/issues/28